### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ ext {
   reformLogging = '5.1.7'
   hmctsNotify = '3.15.1-RELEASE'
   serenity = '2.3.31'
-  log4JVersion = '2.16.0'
+  log4JVersion = '2.17.0'
 }
 
 dependencies {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105