### PR TITLE
Bump java helm chart to 3.7.0

### DIFF
--- a/charts/et-msg-handler/Chart.yaml
+++ b/charts/et-msg-handler/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: et-msg-handler
 home: https://github.com/hmcts/et-msg-handler
-version: 0.0.10
+version: 0.0.11
 description: HMCTS Employment Tribunals Message Handler service
 maintainers:
   - name: HMCTS Employment Tribunals Team
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/


### PR DESCRIPTION
### Change description ###
Bump java helm chart to 3.7.0
https://github.com/hmcts/chart-java/releases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
