### PR TITLE
Bump Java helm chart to 4.0.1

### DIFF
--- a/charts/et-msg-handler/Chart.yaml
+++ b/charts/et-msg-handler/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: et-msg-handler
 home: https://github.com/hmcts/et-msg-handler
-version: 0.0.19
+version: 0.0.20
 description: HMCTS Employment Tribunals Message Handler service
 maintainers:
   - name: HMCTS Employment Tribunals Team
 dependencies:
   - name: java
-    version: 4.0.0
+    version: 4.0.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
     version: 0.4.0


### PR DESCRIPTION
### Change description ###
Bump Java helm chart to 4.0.1 due to deprecation warnings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
